### PR TITLE
Fix Windows Workflow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -166,7 +166,7 @@ tasks {
 				)
 			)
 		}
-		filesMatching("*.mixins.json") { expand(mapOf("java" to stringJavaVersion)) }
+		filesMatching("**/*.mixins.json") { expand(mapOf("java" to stringJavaVersion)) }
 	}
 	java {
 		toolchain {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ val btaChannel = providers.gradleProperty("bta_channel")
 val btaVersion = providers.gradleProperty("bta_version")
 
 val loaderVersion = providers.gradleProperty("loader_version")
+val legacyLwjglVersion = providers.gradleProperty("legacy_lwjgl_version")
 
 val halplibeVersion = providers.gradleProperty("halplibe_version")
 val modMenuVersion = providers.gradleProperty("mod_menu_version")
@@ -79,7 +80,7 @@ dependencies {
     modImplementation("turniplabs:halplibe:${halplibeVersion.get()}")
 	modImplementation("turniplabs:modmenu-bta:${modMenuVersion.get()}")
 	modImplementation("net.fabricmc:fabric-loader:${loaderVersion.get()}")
-	modImplementation("com.github.Better-than-Adventure:legacy-lwjgl3:1.0.5")
+	modImplementation("com.github.Better-than-Adventure:legacy-lwjgl3:${legacyLwjglVersion.get()}")
 
 	implementation(platform("org.lwjgl:lwjgl-bom:${lwjglVersion.get()}"))
 	implementation("org.slf4j:slf4j-api:${slf4jApiVersion.get()}")
@@ -168,7 +169,10 @@ tasks {
 		filesMatching("*.mixins.json") { expand(mapOf("java" to stringJavaVersion)) }
 	}
 	java {
-		toolchain.languageVersion = JavaLanguageVersion.of(javaVersion.get())
+		toolchain {
+			languageVersion = JavaLanguageVersion.of(javaVersion.get())
+			vendor = JvmVendorSpec.ADOPTIUM
+		}
 		sourceCompatibility = JavaVersion.toVersion(javaVersion.get().toInt())
 		targetCompatibility = JavaVersion.toVersion(javaVersion.get().toInt())
 		withSourcesJar()

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,8 @@ mod_name = examplemod
 mod_menu_version = 3.0.0
 # Check this on https://github.com/Turnip-Labs/bta-halplibe/releases/latest/
 halplibe_version = 5.3.1
+# Check this on https://github.com/Better-than-Adventure/legacy-lwjgl3/releases/latest/
+legacy_lwjgl_version = 1.0.6
 ##########################################################################
 # 3rd Party Dependencies
 # Check this on https://central.sonatype.com/artifact/org.slf4j/slf4j-api/
@@ -42,4 +44,8 @@ gson_version = 2.13.2
 commons_lang3_version = 3.19.0
 # This should match the version used by the current BTA release.
 lwjgl_version = 3.3.3
+##########################################################################
+# Plugin Dependency
+# Check this on https://plugins.gradle.org/plugin/org.gradle.toolchains.foojay-resolver-convention/
+foojay_resolver_version = 1.0.0
 ##########################################################################

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,13 @@ pluginManagement {
 		maven("https://maven.glass-launcher.net/babric") { name = "Babric" }
 		maven("https://maven.thesignalumproject.net/infrastructure") { name = "SignalumMavenInfrastructure" }
 	}
+	val foojayResolverVersion = providers.gradleProperty("foojay_resolver_version")
 	val loomVersion = providers.gradleProperty("loom_version")
-	plugins { id("fabric-loom").version(loomVersion.get()) }
+	plugins {
+		id("org.gradle.toolchains.foojay-resolver-convention").version(foojayResolverVersion.get())
+		id("fabric-loom").version(loomVersion.get())
+	}
+}
+plugins {
+	id("org.gradle.toolchains.foojay-resolver-convention")
 }

--- a/src/main/java/turniplabs/examplemod/ExampleMod.java
+++ b/src/main/java/turniplabs/examplemod/ExampleMod.java
@@ -6,32 +6,23 @@ import org.slf4j.LoggerFactory;
 import turniplabs.halplibe.util.GameStartEntrypoint;
 import turniplabs.halplibe.util.RecipeEntrypoint;
 
-
 public class ExampleMod implements ModInitializer, RecipeEntrypoint, GameStartEntrypoint {
-    public static final String MOD_ID = "examplemod";
-    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
-    @Override
-    public void onInitialize() {
-        LOGGER.info("ExampleMod initialized.");
-    }
-
+	public static final String MOD_ID = "examplemod";
+	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 	@Override
-	public void onRecipesReady() {
-
+	public void onInitialize() {
+		LOGGER.info("ExampleMod initialized.");
 	}
 
 	@Override
-	public void initNamespaces() {
-
-	}
+	public void onRecipesReady() {}
 
 	@Override
-	public void beforeGameStart() {
-
-	}
+	public void initNamespaces() {}
 
 	@Override
-	public void afterGameStart() {
+	public void beforeGameStart() {}
 
-	}
+	@Override
+	public void afterGameStart() {}
 }


### PR DESCRIPTION
This fixes the Windows workflow by letting Gradle grab the JDK you need if your machine is missing it. It also moves `legacy_lwjgl` to the `gradle.properties` with all other dependencies. It also improves `.mixins.json` pattern matching to avoid hardcoding the Java version.