### PR TITLE
Build script improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,33 +3,7 @@ plugins {
     java
 }
 
-val lwjglNatives = Pair(
-	System.getProperty("os.name")!!,
-	System.getProperty("os.arch")!!
-).let { (name, arch) ->
-	when {
-		"FreeBSD" == name ->
-			"natives-freebsd"
-		arrayOf("Linux", "SunOS", "Unit").any { name.startsWith(it) } ->
-			if (arrayOf("arm", "aarch64").any { arch.startsWith(it) })
-				"natives-linux${if (arch.contains("64") || arch.startsWith("armv8")) "-arm64" else "-arm32"}"
-			else if (arch.startsWith("ppc"))
-				"natives-linux-ppc64le"
-			else if (arch.startsWith("riscv"))
-				"natives-linux-riscv64"
-			else
-				"natives-linux"
-		arrayOf("Mac OS X", "Darwin").any { name.startsWith(it) } ->
-			"natives-macos${if (arch.startsWith("aarch64")) "-arm64" else ""}"
-		arrayOf("Windows").any { name.startsWith(it) } ->
-			if (arch.contains("64"))
-				"natives-windows${if (arch.startsWith("aarch64")) "-arm64" else ""}"
-			else
-				"natives-windows-x86"
-		else ->
-			throw Error("Unrecognized or unsupported platform. Please set \"lwjglNatives\" manually")
-	}
-}
+val lwjglNatives = resolveLwjglNatives()
 
 val modVersion = "${providers.gradleProperty("mod_version").get()}+${libs.versions.bta.get()}"
 val modGroup: Provider<String> = providers.gradleProperty("mod_group")
@@ -158,4 +132,34 @@ configurations.configureEach {
 	exclude(group = "net.java.jinput")
 	exclude(group = "net.sf.jopt-simple")
 	exclude(group = "net.minecraft", module = "launchwrapper")
+}
+
+fun resolveLwjglNatives(): String { // Sourced from https://www.lwjgl.org/
+	return Pair(
+		System.getProperty("os.name")!!,
+		System.getProperty("os.arch")!!
+	).let { (name, arch) ->
+		when {
+			"FreeBSD" == name ->
+				"natives-freebsd"
+			arrayOf("Linux", "SunOS", "Unit").any { name.startsWith(it) } ->
+				if (arrayOf("arm", "aarch64").any { arch.startsWith(it) })
+					"natives-linux${if (arch.contains("64") || arch.startsWith("armv8")) "-arm64" else "-arm32"}"
+				else if (arch.startsWith("ppc"))
+					"natives-linux-ppc64le"
+				else if (arch.startsWith("riscv"))
+					"natives-linux-riscv64"
+				else
+					"natives-linux"
+			arrayOf("Mac OS X", "Darwin").any { name.startsWith(it) } ->
+				"natives-macos${if (arch.startsWith("aarch64")) "-arm64" else ""}"
+			arrayOf("Windows").any { name.startsWith(it) } ->
+				if (arch.contains("64"))
+					"natives-windows${if (arch.startsWith("aarch64")) "-arm64" else ""}"
+				else
+					"natives-windows-x86"
+			else ->
+				throw Error("Unrecognized or unsupported platform. Please set \"lwjglNatives\" manually")
+		}
+	}
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,33 @@ plugins {
     java
 }
 
-val osName: String = System.getProperty("os.name").lowercase().replace(" ", "")
-val lwjglNativeList = arrayOf("macos", "windows", "linux")
-val lwjglNativesName = "natives-${lwjglNativeList.find { it in osName }}"
+val lwjglNatives = Pair(
+	System.getProperty("os.name")!!,
+	System.getProperty("os.arch")!!
+).let { (name, arch) ->
+	when {
+		"FreeBSD" == name ->
+			"natives-freebsd"
+		arrayOf("Linux", "SunOS", "Unit").any { name.startsWith(it) } ->
+			if (arrayOf("arm", "aarch64").any { arch.startsWith(it) })
+				"natives-linux${if (arch.contains("64") || arch.startsWith("armv8")) "-arm64" else "-arm32"}"
+			else if (arch.startsWith("ppc"))
+				"natives-linux-ppc64le"
+			else if (arch.startsWith("riscv"))
+				"natives-linux-riscv64"
+			else
+				"natives-linux"
+		arrayOf("Mac OS X", "Darwin").any { name.startsWith(it) } ->
+			"natives-macos${if (arch.startsWith("aarch64")) "-arm64" else ""}"
+		arrayOf("Windows").any { name.startsWith(it) } ->
+			if (arch.contains("64"))
+				"natives-windows${if (arch.startsWith("aarch64")) "-arm64" else ""}"
+			else
+				"natives-windows-x86"
+		else ->
+			throw Error("Unrecognized or unsupported platform. Please set \"lwjglNatives\" manually")
+	}
+}
 
 val modVersion: Provider<String> = providers.gradleProperty("mod_version")
 val modGroup: Provider<String> = providers.gradleProperty("mod_group")
@@ -50,11 +74,11 @@ dependencies {
 	runtimeClasspath(libs.clientJar)
 	val lwjglVer = libs.versions.lwjgl.get()
 	localRuntime(platform("org.lwjgl:lwjgl-bom:${lwjglVer}"))
-	localRuntime("org.lwjgl:lwjgl::$lwjglNativesName")
-	localRuntime("org.lwjgl:lwjgl-glfw::$lwjglNativesName")
-	localRuntime("org.lwjgl:lwjgl-openal::$lwjglNativesName")
-	localRuntime("org.lwjgl:lwjgl-opengl::$lwjglNativesName")
-	localRuntime("org.lwjgl:lwjgl-stb::$lwjglNativesName")
+	localRuntime("org.lwjgl:lwjgl::$lwjglNatives")
+	localRuntime("org.lwjgl:lwjgl-glfw::$lwjglNatives")
+	localRuntime("org.lwjgl:lwjgl-openal::$lwjglNatives")
+	localRuntime("org.lwjgl:lwjgl-opengl::$lwjglNatives")
+	localRuntime("org.lwjgl:lwjgl-stb::$lwjglNatives")
 }
 java {
 	toolchain {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,12 @@
-import com.smushytaco.lwjgl_gradle.Preset
 plugins {
 	alias(libs.plugins.loom)
-	alias(libs.plugins.lwjgl)
     java
 }
+
+val osName: String = System.getProperty("os.name").lowercase().replace(" ", "")
+val lwjglNativeList = arrayOf("macos", "windows", "linux")
+val lwjglNativesName = "natives-${lwjglNativeList.find { it in osName }}"
+
 val modVersion: Provider<String> = providers.gradleProperty("mod_version")
 val modGroup: Provider<String> = providers.gradleProperty("mod_group")
 val modName: Provider<String> = providers.gradleProperty("mod_name")
@@ -22,47 +25,36 @@ repositories {
     maven("https://maven.thesignalumproject.net/infrastructure") { name = "SignalumMavenInfrastructure" }
     maven("https://maven.thesignalumproject.net/releases") { name = "SignalumMavenReleases" }
 	maven("https://maven.thesignalumproject.net/nightly") { name = "SignalumMavenNightly" }
-    ivy("https://github.com/Better-than-Adventure") {
-        patternLayout { artifact("[organisation]/releases/download/[revision]/[module]-bta-[revision].jar") }
-        metadataSources { artifact() }
-    }
-    ivy("https://downloads.betterthanadventure.net/bta-client/${libs.versions.btaChannel.get()}/") {
-        patternLayout { artifact("/v[revision]/client.jar") }
-        metadataSources { artifact() }
-    }
-    ivy("https://downloads.betterthanadventure.net/bta-server/${libs.versions.btaChannel.get()}/") {
-        patternLayout { artifact("/v[revision]/server.jar") }
-        metadataSources { artifact() }
-    }
     ivy("https://piston-data.mojang.com") {
         patternLayout { artifact("v1/[organisation]/[revision]/[module].jar") }
         metadataSources { artifact() }
     }
 }
-lwjgl {
-	version = libs.versions.lwjgl
-	implementation(Preset.MINIMAL_OPENGL)
-}
 dependencies {
     minecraft("::${libs.versions.bta.get()}")
 
-	runtimeOnly(libs.clientJar)
+	// Required at compilation & runtime
+	// included in builds as a runtime dependency
 	implementation(libs.loader)
-	// If you do not need Halplibe you can comment out or delete this line.
-	implementation(libs.halplibe)
-	implementation(libs.modMenu)
-	implementation(libs.legacyLwjgl)
+	implementation(libs.halplibe) // If you do not need halplibe you can delete this line
 
-	implementation(libs.slf4jApi)
-	implementation(libs.guava)
-	implementation(libs.log4j.slf4j2.impl)
-	implementation(libs.log4j.core)
-	implementation(libs.log4j.api)
-	implementation(libs.log4j.api12)
-	implementation(libs.gson)
+	// Only required at compilation
+	// provides documentation, can be removed if that isn't needed
+	compileOnly(libs.bundles.btaLwjgl)
+	compileOnly(libs.joml)
+	compileOnly(libs.joml.primitives)
+	compileOnly(libs.slf4jApi)
 
-	implementation(libs.commonsLang3)
-	include(libs.commonsLang3)
+	// Only required for development/launch at runtime, won't be part of any builds
+	localRuntime(libs.modMenu) // Optional, can be removed
+	runtimeClasspath(libs.clientJar)
+	val lwjglVer = libs.versions.lwjgl.get()
+	localRuntime(platform("org.lwjgl:lwjgl-bom:${lwjglVer}"))
+	localRuntime("org.lwjgl:lwjgl::$lwjglNativesName")
+	localRuntime("org.lwjgl:lwjgl-glfw::$lwjglNativesName")
+	localRuntime("org.lwjgl:lwjgl-openal::$lwjglNativesName")
+	localRuntime("org.lwjgl:lwjgl-opengl::$lwjglNativesName")
+	localRuntime("org.lwjgl:lwjgl-stb::$lwjglNativesName")
 }
 java {
 	toolchain {
@@ -120,10 +112,21 @@ tasks {
 			"java" to libs.versions.java.get(),
 			"modmenu" to libs.versions.modMenu.get()
 		)
-		inputs.properties(resourceMap)
-		filesMatching("fabric.mod.json") { expand(resourceMap) }
-		filesMatching("**/*.mixins.json") { expand(resourceMap.filterKeys { it == "java" }) }
+		duplicatesStrategy = DuplicatesStrategy.INCLUDE
+		with(copySpec {
+			from("src/main/resources/") {
+				include("fabric.mod.json")
+				include("*.mixins.json")
+				expand(resourceMap)
+			}
+		})
 	}
 }
-// Removes LWJGL2 dependencies
-configurations.configureEach { exclude(group = "org.lwjgl.lwjgl") }
+// Removes all outdated manifest.json dependencies
+configurations.configureEach {
+	exclude(group = "org.lwjgl.lwjgl")
+	exclude(group = "net.java.jutils")
+	exclude(group = "net.java.jinput")
+	exclude(group = "net.sf.jopt-simple")
+	exclude(group = "net.minecraft", module = "launchwrapper")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ val lwjglNatives = Pair(
 	}
 }
 
-val modVersion: Provider<String> = providers.gradleProperty("mod_version")
+val modVersion = "${providers.gradleProperty("mod_version").get()}+${libs.versions.bta.get()}"
 val modGroup: Provider<String> = providers.gradleProperty("mod_group")
 val modName: Provider<String> = providers.gradleProperty("mod_name")
 
@@ -39,9 +39,10 @@ val javaVersion: Provider<Int> = libs.versions.java.map { it.toInt() }
 
 base.archivesName = modName
 group = modGroup.get()
-version = modVersion.get()
+version = modVersion
 loom {
-    customMinecraftMetadata.set("https://downloads.betterthanadventure.net/bta-client/${libs.versions.btaChannel.get()}/${libs.versions.bta.get()}/manifest.json")
+	val btaVersion = "${if (libs.versions.btaChannel.get() == "nightly") "" else "v"}${libs.versions.bta.get()}"
+    customMinecraftMetadata.set("https://downloads.betterthanadventure.net/bta-client/${libs.versions.btaChannel.get()}/$btaVersion/manifest.json")
 }
 repositories {
     mavenCentral()
@@ -130,12 +131,16 @@ tasks {
 	}
 	processResources {
 		val resourceMap = mapOf(
-			"version" to modVersion.get(),
+			"version" to modVersion,
 			"fabricloader" to libs.versions.loader.get(),
 			"halplibe" to libs.versions.halplibe.get(),
 			"java" to libs.versions.java.get(),
 			"modmenu" to libs.versions.modMenu.get()
 		)
+		// This is needed for gradle to recognize changes
+		// made to expanded files
+		inputs.properties(resourceMap)
+
 		duplicatesStrategy = DuplicatesStrategy.INCLUDE
 		with(copySpec {
 			from("src/main/resources/") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,6 @@
 # Plugins
 # Check this on https://github.com/FabricMC/fabric-loom/releases/latest/
 loom = "1.15-SNAPSHOT"
-# Check this on https://plugins.gradle.org/plugin/com.smushytaco.lwjgl3/
-lwjglPlugin = "1.0.2"
 ##########################################################################
 # Java Configuration
 # The Java version the JDK will be for compiling and running code.
@@ -29,34 +27,31 @@ legacyLwjgl = "1.0.6"
 # Dependencies
 # Check this on https://central.sonatype.com/artifact/org.slf4j/slf4j-api/
 slf4jApi = "2.0.17"
-# Check this on https://central.sonatype.com/artifact/com.google.guava/guava/
-guava = "33.5.0-jre"
-# Check this on https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j-api/
-log4j = "2.20.0"
-# Check this on https://central.sonatype.com/artifact/com.google.code.gson/gson/
-gson = "2.13.2"
-# Check this on https://central.sonatype.com/artifact/org.apache.commons/commons-lang3/
-commonsLang3 = "3.20.0"
 # This should match the version used by the current BTA release.
 lwjgl = "3.3.3"
+
+joml = "1.10.8" # Note: BTA uses 1.10.7, patch 8 removes the kotlin stdlib dependency
+jomlPrimitivess = "1.10.0"
 ##########################################################################
 
 [libraries]
 loader = { group = "net.fabricmc", name = "fabric-loader", version.ref = "loader" }
 halplibe = { group = "turniplabs", name = "halplibe", version.ref = "halplibe" }
 modMenu = { group = "turniplabs", name = "modmenu-bta", version.ref = "modMenu" }
-legacyLwjgl = { group = "legacy-lwjgl3", name = "legacy-lwjgl3", version.ref = "legacyLwjgl" }
+legacyLwjgl = { group = "com.github.Better-than-Adventure", name = "legacy-lwjgl3", version.ref = "legacyLwjgl" }
 slf4jApi = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4jApi" }
-guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
-log4j-slf4j2-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j2-impl", version.ref = "log4j" }
-log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
-log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
-log4j-api12 = { group = "org.apache.logging.log4j", name = "log4j-1.2-api", version.ref = "log4j" }
-gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
-commonsLang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commonsLang3" }
 # https://piston-data.mojang.com/v1/objects/43db9b498cb67058d2e12d394e6507722e71bb45/client.jar
 clientJar = { group = "objects", name = "client", version = "43db9b498cb67058d2e12d394e6507722e71bb45" }
+joml = { group = "org.joml", name = "joml", version.ref = "joml" }
+joml-primitives = { group = "org.joml", name = "joml-primitives", version.ref = "jomlPrimitivess" }
+lwjgl = { group = "org.lwjgl", name = "lwjgl", version.ref = "lwjgl"}
+lwjgl-glfw = { group = "org.lwjgl", name = "lwjgl-glfw", version.ref = "lwjgl"}
+lwjgl-openal = { group = "org.lwjgl", name = "lwjgl-openal", version.ref = "lwjgl"}
+lwjgl-opengl = { group = "org.lwjgl", name = "lwjgl-opengl", version.ref = "lwjgl"}
+lwjgl-stb = { group = "org.lwjgl", name = "lwjgl-stb", version.ref = "lwjgl"}
+
+[bundles]
+btaLwjgl = [ "lwjgl", "lwjgl-glfw", "lwjgl-openal", "lwjgl-opengl", "lwjgl-stb", "legacyLwjgl" ]
 
 [plugins]
 loom = { id = "net.fabricmc.fabric-loom", version.ref = "loom" }
-lwjgl = { id = "com.smushytaco.lwjgl3", version.ref = "lwjglPlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ gradleJava = "21"
 ##########################################################################
 # Mod Dependencies
 # Check this on https://downloads.betterthanadventure.net/bta-client/
-bta = "v8.0-pre2"
+bta = "8.0-pre2"
 # Options are release, prerelease, nightly, and misc.
 btaChannel = "prerelease"
 # Check this on https://maven.thesignalumproject.net/#/infrastructure/net/fabricmc/fabric-loader/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ btaChannel = "prerelease"
 # Check this on https://maven.thesignalumproject.net/#/infrastructure/net/fabricmc/fabric-loader/
 loader = "0.18.4-bta.11"
 # Check this on https://github.com/Turnip-Labs/ModMenu/releases/latest/
-modMenu = "5.0.0"
+modMenu = "5.0.1"
 # Check this on https://github.com/Turnip-Labs/bta-halplibe/releases/latest/
 halplibe = "6.0.2"
 # Check this on https://github.com/Better-than-Adventure/legacy-lwjgl3/releases/latest/

--- a/src/main/java/turniplabs/examplemod/ExampleMod.java
+++ b/src/main/java/turniplabs/examplemod/ExampleMod.java
@@ -4,35 +4,19 @@ import net.fabricmc.api.ModInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import turniplabs.halplibe.HalpLibe;
-import turniplabs.halplibe.util.GameStartEntrypoint;
-import turniplabs.halplibe.util.RecipeEntrypoint;
+import turniplabs.halplibe.event.defs.CommonEvents;
 
-public class ExampleMod implements ModInitializer, GameStartEntrypoint, RecipeEntrypoint {
+public class ExampleMod implements ModInitializer {
 	public static final String MOD_ID = HalpLibe.registerMod("examplemod", true);
 	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
 	@Override
 	public void onInitialize() {
 		LOGGER.info("ExampleMod initialized.");
+		CommonEvents.BEFORE_GAME_START.listen(ExampleMod::beforeGameStart);
 	}
 
-	@Override
-	public void beforeGameStart() {
-
-	}
-
-	@Override
-	public void afterGameStart() {
-
-	}
-
-	@Override
-	public void onRecipesReady() {
-
-	}
-
-	@Override
-	public void initNamespaces() {
-
+	private static void beforeGameStart() {
+		LOGGER.info("This is an example event!");
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,15 +17,6 @@
 	"entrypoints": {
 		"main": [
 			"turniplabs.examplemod.ExampleMod"
-		],
-		"beforeGameStart": [
-			"turniplabs.examplemod.ExampleMod"
-		],
-		"afterGameStart": [
-			"turniplabs.examplemod.ExampleMod"
-		],
-		"recipesReady": [
-			"turniplabs.examplemod.ExampleMod"
 		]
 	},
 	"mixins": [


### PR DESCRIPTION
## Changes
Read a detailed explanation at https://github.com/Turnip-Labs/bta-halplibe/pull/88

**Summary:**
- Now uses proper dependency configurations instead of just ``implementation``
- Removed the LWJGL plugin in favor of more granular control over its various components
- Fixed using github for legacy lwjgl instead of the signalum maven
- Replaced ``filesMatching`` with ``copySpec`` to suppress a warning

This PR depends on halplibe and modmenu also updating their build scripts accordingly, otherwise the gradle sync fails due to incompatible changes.